### PR TITLE
Fix FDKTokenIssueError constructor

### DIFF
--- a/fdk_client/common/exceptions.py
+++ b/fdk_client/common/exceptions.py
@@ -30,6 +30,6 @@ class FDKClientValidationError(Exception):
 
 class FDKTokenIssueError(Exception):
     """FDK Token Issue Error"""
-    def __ini__(self, message=""):
+    def __init__(self, message=""):
         """Initialize function __init__."""
         super(FDKTokenIssueError, self).__init__(message)

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -1,0 +1,6 @@
+from fdk_client.common.exceptions import FDKTokenIssueError
+
+
+def test_fdk_token_issue_error_init():
+    err = FDKTokenIssueError("test message")
+    assert str(err) == "test message"


### PR DESCRIPTION
## Summary
- correct the constructor name for `FDKTokenIssueError`
- add a basic unit test for the constructor

## Testing
- `pytest tests/exceptions_test.py -q`
- `pytest -q` *(fails: network and credential errors)*