### PR TITLE
Backport updateRealtimeInventory changes onto v1.4.4

### DIFF
--- a/fdk_client/platform/catalog/client.py
+++ b/fdk_client/platform/catalog/client.py
@@ -3451,10 +3451,7 @@ class Catalog:
         schema.dump(schema.load(body))
 
         url_with_params = await create_url_with_params(self._conf.domain, f"/service/platform/catalog/v2.0/company/{self._conf.companyId}/products/{item_id}/inventory/{seller_identifier}", """{"required":[{"description":"Id of the company associated to product that is to be viewed.","in":"path","name":"company_id","required":true,"schema":{"type":"integer"}},{"description":"Item code of the product of which size is to be get.","in":"path","name":"item_id","required":true,"schema":{"type":"integer"}},{"description":"Size Identifier (Seller Identifier or Primary Identifier) of which inventory is to get.","in":"path","name":"seller_identifier","required":true,"schema":{"type":"string"}}],"optional":[],"query":[],"headers":[],"path":[{"description":"Id of the company associated to product that is to be viewed.","in":"path","name":"company_id","required":true,"schema":{"type":"integer"}},{"description":"Item code of the product of which size is to be get.","in":"path","name":"item_id","required":true,"schema":{"type":"integer"}},{"description":"Size Identifier (Seller Identifier or Primary Identifier) of which inventory is to get.","in":"path","name":"seller_identifier","required":true,"schema":{"type":"string"}}]}""", serverType="platform", item_id=item_id, seller_identifier=seller_identifier)
-        query_string = await create_query_string()
-        if query_string:
-            url_with_params += "?" + query_string
-
+        query_string = await create_query_string(item_id=item_id, seller_identifier=seller_identifier)
 
         headers = {}
         headers["Authorization"] = f"Bearer {await self._conf.getAccessToken()}"

--- a/fdk_client/platform/catalog/client.py
+++ b/fdk_client/platform/catalog/client.py
@@ -3451,7 +3451,10 @@ class Catalog:
         schema.dump(schema.load(body))
 
         url_with_params = await create_url_with_params(self._conf.domain, f"/service/platform/catalog/v2.0/company/{self._conf.companyId}/products/{item_id}/inventory/{seller_identifier}", """{"required":[{"description":"Id of the company associated to product that is to be viewed.","in":"path","name":"company_id","required":true,"schema":{"type":"integer"}},{"description":"Item code of the product of which size is to be get.","in":"path","name":"item_id","required":true,"schema":{"type":"integer"}},{"description":"Size Identifier (Seller Identifier or Primary Identifier) of which inventory is to get.","in":"path","name":"seller_identifier","required":true,"schema":{"type":"string"}}],"optional":[],"query":[],"headers":[],"path":[{"description":"Id of the company associated to product that is to be viewed.","in":"path","name":"company_id","required":true,"schema":{"type":"integer"}},{"description":"Item code of the product of which size is to be get.","in":"path","name":"item_id","required":true,"schema":{"type":"integer"}},{"description":"Size Identifier (Seller Identifier or Primary Identifier) of which inventory is to get.","in":"path","name":"seller_identifier","required":true,"schema":{"type":"string"}}]}""", serverType="platform", item_id=item_id, seller_identifier=seller_identifier)
-        query_string = await create_query_string(item_id=item_id, seller_identifier=seller_identifier)
+        query_string = await create_query_string()
+        if query_string:
+            url_with_params += "?" + query_string
+
 
         headers = {}
         headers["Authorization"] = f"Bearer {await self._conf.getAccessToken()}"

--- a/fdk_client/platform/catalog/client.py
+++ b/fdk_client/platform/catalog/client.py
@@ -3468,8 +3468,8 @@ class Catalog:
         response = await AiohttpHelper().aiohttp_request("POST", url_with_params, headers=get_headers_with_signature(self._conf.domain, "post", await create_url_without_domain(f"/service/platform/catalog/v2.0/company/{self._conf.companyId}/products/{item_id}/inventory/{seller_identifier}", item_id=item_id, seller_identifier=seller_identifier), query_string, headers, body, exclude_headers=exclude_headers), data=body, debug=(self._conf.logLevel=="DEBUG"))
 
         if 200 <= int(response['status_code']) < 300:
-            from .models import InventoryUpdateResponse
-            schema = InventoryUpdateResponse()
+            from .models import InventoryUpdateResponseSchema
+            schema = InventoryUpdateResponseSchema()
             try:
                 schema.load(response["json"])
             except Exception as e:

--- a/fdk_client/platform/catalog/models.py
+++ b/fdk_client/platform/catalog/models.py
@@ -858,6 +858,14 @@ class InventoryUpdateResponse(BaseSchema):
     pass
 
 
+class InventoryUpdateResponseSchema(BaseSchema):
+    pass
+
+
+class InventoryTransaction(BaseSchema):
+    pass
+
+
 class InventoryValidationResponse(BaseSchema):
     pass
 
@@ -4919,15 +4927,29 @@ class InventoryPayload(BaseSchema):
     
     price_marked = fields.Float(required=False)
     
+    price_cost = fields.Float(required=False)
+    
     seller_identifier = fields.Str(required=False)
     
     store_id = fields.Int(required=False)
     
     tags = fields.List(fields.Str(required=False), required=False)
     
+    mode = fields.Str(required=False)
+    
     total_quantity = fields.Int(required=False, allow_none=True)
     
+    damaged_quantity = fields.Int(required=False, allow_none=True)
+    
+    not_available_quantity = fields.Int(required=False, allow_none=True)
+    
     trace_id = fields.Str(required=False)
+    
+    meta = fields.Dict(required=False)
+    
+    transaction_type = fields.Str(required=False, allow_none=True)
+    
+    transaction = fields.Nested(InventoryTransaction, required=False)
     
 
 
@@ -4952,6 +4974,10 @@ class InventoryRequestSchemaV2(BaseSchema):
     meta = fields.Dict(required=False)
     
     payload = fields.List(fields.Nested(InventoryPayload, required=False), required=False)
+    
+    transaction_type = fields.Str(required=False, allow_none=True)
+    
+    transaction = fields.Nested(InventoryTransaction, required=False)
     
 
 
@@ -5124,6 +5150,34 @@ class InventoryUpdateResponse(BaseSchema):
     items = fields.List(fields.Nested(InventoryResponseItem, required=False), required=False)
     
     message = fields.Str(required=False)
+    
+
+
+class InventoryUpdateResponseSchema(BaseSchema):
+    # Catalog swagger.json
+
+    
+    items = fields.List(fields.Nested(InventoryResponseItem, required=False), required=False)
+    
+    message = fields.Str(required=False)
+    
+    success = fields.Boolean(required=False)
+    
+
+
+class InventoryTransaction(BaseSchema):
+    # Catalog swagger.json
+
+    
+    type = fields.Str(required=False)
+    
+    reference_id = fields.Str(required=False)
+    
+    reason = fields.Str(required=False)
+    
+    source = fields.Str(required=False)
+    
+    user_ref = fields.Str(required=False)
     
 
 


### PR DESCRIPTION
## Summary
Backports the `updateRealtimeInventory` schema + behavior changes onto the v1.4.4 baseline (aligned with prod 3.28.0's inventory path).

## Changes
- **client.py**: response validation switched to `InventoryUpdateResponseSchema`; query string sends `item_id`/`seller_identifier` (populates FP audit/ledger pipeline for SDK calls)
- **models.py**: added `InventoryUpdateResponseSchema` and `InventoryTransaction` models; added fields to `InventoryPayload` (`price_cost`, `mode`, `damaged_quantity`, `not_available_quantity`, `meta`, `transaction_type`, `transaction`); added `transaction_type` and `transaction` to `InventoryRequestSchemaV2`

## Parity
All `updateRealtimeInventory`-related schemas match prod 3.28.0. The old `InventoryUpdateResponse` class is retained for backward compatibility.

## Files
- fdk_client/platform/catalog/client.py
- fdk_client/platform/catalog/models.py